### PR TITLE
Add template-workflow for adding issues to project

### DIFF
--- a/workflow-templates/issue_handler.properties.json
+++ b/workflow-templates/issue_handler.properties.json
@@ -1,0 +1,5 @@
+{
+    "name": "Add issues to esp-rs project",
+    "description": "Add issues to esp-rs project.",
+    "iconName": "check"
+}

--- a/workflow-templates/issue_handler.yml
+++ b/workflow-templates/issue_handler.yml
@@ -1,0 +1,16 @@
+name: Add new issues to project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/esp-rs/projects/2
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/workflow-templates/issue_handler.yml
+++ b/workflow-templates/issue_handler.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/esp-rs/projects/2
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ secrets.PAT }}


### PR DESCRIPTION
With this template, we can easily add the workflow in any repo of the organization
  - Example in my personal account
     - [Template](https://github.com/SergioGasquez/.github/tree/main/workflow-templates)
     - When adding a new workflow in any of my repos I can use the template

Since the [workflow requires a PAT](https://github.com/actions/add-to-project#inputs) we could set it as a [secret at the organization level](https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-encrypted-secrets-for-your-repository-and-organization-for-github-codespaces#adding-secrets-for-an-organization), so we do not need to add a secret per repo
I have no way of check this since I can't create secrets in esp-rs and I am not admin in any org, but I guess it should do the trick